### PR TITLE
Only include index.json on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "@launchpadlab/prettier-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "main": "index.json",
   "repository": "https://github.com/launchpadlab/prettier-config",
   "author": "dpikt",
   "license": "MIT",
+  "files": ["index.json"],
   "peerDependencies": {
     "prettier": "^1.0 || ^2.0 || ^3.0"
   }


### PR DESCRIPTION
v2.0.0 published to npm and included the `.github` folder. We don't want that 🙂 

Dry run results of `npm publish`:
![](https://p-1MFmr4.b2.n0.cdn.getcloudapp.com/items/v1uW9Y7L/e6c4c01d-5339-4377-8f0a-27c594d4eefa.jpg?v=3d40a9db5e0fae1cca8fc386a9fb295c)